### PR TITLE
libc: memcpy_base: Disable opt for certain targets

### DIFF
--- a/libc/arch-arm/krait/krait.mk
+++ b/libc/arch-arm/krait/krait.mk
@@ -1,12 +1,19 @@
 libc_bionic_src_files_arm += \
     arch-arm/cortex-a15/bionic/memchr.S \
-    arch-arm/krait/bionic/memcpy.S \
     arch-arm/krait/bionic/memset.S \
     arch-arm/krait/bionic/strcmp.S \
     arch-arm/krait/bionic/__strcat_chk.S \
     arch-arm/krait/bionic/__strcpy_chk.S \
     arch-arm/krait/bionic/memmove.S
 
+#For some targets we don't need this optimization
+ifeq ($(TARGET_CPU_MEMCPY_BASE_OPT_DISABLE),true)
+libc_bionic_src_files_arm += \
+    arch-arm/cortex-a15/bionic/memcpy.S
+else
+libc_bionic_src_files_arm += \
+    arch-arm/krait/bionic/memcpy.S
+endif
 
 # Use cortex-a15 versions of strcat/strcpy/strlen and standard memmove
 libc_bionic_src_files_arm += \


### PR DESCRIPTION
memcpy_base.S optimization is yielding low
memory scores for 8x26 and 8x10. So this opt is
being conditionally compiled.

CRs-fixed: 790279

Change-Id: I5a5a60dfa81d86fd43b6be73fa344da861ebb33c